### PR TITLE
Release/1.6

### DIFF
--- a/Docs/releases.md
+++ b/Docs/releases.md
@@ -1,5 +1,8 @@
 # Releases
 
+## New in 1.6
+* Honour Roslyn `ProductionContext.Cancellation.IsCancellationRequested` to improve performance
+
 ## New in 1.5
 * Fixed IndexOutOfBoundsException when using attribute optional inputs [Fixes #19](https://github.com/mrpmorris/Morris.Moxy/issues/19)
 * Static and aliased using clauses were not being output correctly [Fixes #20](https://github.com/mrpmorris/Morris.Moxy/issues/20)

--- a/Docs/releases.md
+++ b/Docs/releases.md
@@ -3,6 +3,7 @@
 ## New in 1.6
 * Honour Roslyn `ProductionContext.Cancellation.IsCancellationRequested` to improve performance
 * Do not output `typeof()` in generated source when user has specified a type name as a mixin argument [Fixes #28](https://github.com/mrpmorris/Morris.Moxy/issues/28)
+* Use object instead of string for variable values [Fixes #30](https://github.com/mrpmorris/Morris.Moxy/issues/30)
 
 ## New in 1.5
 * Fixed IndexOutOfBoundsException when using attribute optional inputs [Fixes #19](https://github.com/mrpmorris/Morris.Moxy/issues/19)

--- a/Docs/releases.md
+++ b/Docs/releases.md
@@ -2,6 +2,7 @@
 
 ## New in 1.6
 * Honour Roslyn `ProductionContext.Cancellation.IsCancellationRequested` to improve performance
+* Do not output `typeof()` in generated source when user has specified a type name as a mixin argument [Fixes #28](https://github.com/mrpmorris/Morris.Moxy/issues/28)
 
 ## New in 1.5
 * Fixed IndexOutOfBoundsException when using attribute optional inputs [Fixes #19](https://github.com/mrpmorris/Morris.Moxy/issues/19)

--- a/Publish.bat
+++ b/Publish.bat
@@ -1,5 +1,5 @@
 cls
-@echo **** 1.5.0 : UPDATED THE VERSION NUMBER IN THE PROJECT *AND* BATCH FILE? ****
+@echo **** 1.6.0-Beta1 : UPDATED THE VERSION NUMBER IN THE PROJECT *AND* BATCH FILE? ****
 pause
 
 cls
@@ -7,9 +7,9 @@ cls
 
 @echo ======================
 
-set /p ShouldPublish=Publish 1.5.0 [yes]?
+set /p ShouldPublish=Publish 1.6.0-Beta1 [yes]?
 @if "%ShouldPublish%" == "yes" (
 	@echo PUBLISHING
-	dotnet nuget push .\Source\Lib\Morris.Moxy\bin\Release\Morris.Moxy.1.5.0.nupkg -k %MORRIS.NUGET.KEY% -s https://api.nuget.org/v3/index.json
+	dotnet nuget push .\Source\Lib\Morris.Moxy\bin\Release\Morris.Moxy.1.6.0-Beta1.nupkg -k %MORRIS.NUGET.KEY% -s https://api.nuget.org/v3/index.json
 )
 

--- a/Publish.bat
+++ b/Publish.bat
@@ -1,5 +1,5 @@
 cls
-@echo **** 1.6.0-Beta1 : UPDATED THE VERSION NUMBER IN THE PROJECT *AND* BATCH FILE? ****
+@echo **** 1.6.0-Beta2 : UPDATED THE VERSION NUMBER IN THE PROJECT *AND* BATCH FILE? ****
 pause
 
 cls
@@ -7,9 +7,9 @@ cls
 
 @echo ======================
 
-set /p ShouldPublish=Publish 1.6.0-Beta1 [yes]?
+set /p ShouldPublish=Publish 1.6.0-Beta2 [yes]?
 @if "%ShouldPublish%" == "yes" (
 	@echo PUBLISHING
-	dotnet nuget push .\Source\Lib\Morris.Moxy\bin\Release\Morris.Moxy.1.6.0-Beta1.nupkg -k %MORRIS.NUGET.KEY% -s https://api.nuget.org/v3/index.json
+	dotnet nuget push .\Source\Lib\Morris.Moxy\bin\Release\Morris.Moxy.1.6.0-Beta2.nupkg -k %MORRIS.NUGET.KEY% -s https://api.nuget.org/v3/index.json
 )
 

--- a/Publish.bat
+++ b/Publish.bat
@@ -1,5 +1,5 @@
 cls
-@echo **** 1.6.0-Beta2 : UPDATED THE VERSION NUMBER IN THE PROJECT *AND* BATCH FILE? ****
+@echo **** 1.6.0 : UPDATED THE VERSION NUMBER IN THE PROJECT *AND* BATCH FILE? ****
 pause
 
 cls
@@ -7,9 +7,9 @@ cls
 
 @echo ======================
 
-set /p ShouldPublish=Publish 1.6.0-Beta2 [yes]?
+set /p ShouldPublish=Publish 1.6.0 [yes]?
 @if "%ShouldPublish%" == "yes" (
 	@echo PUBLISHING
-	dotnet nuget push .\Source\Lib\Morris.Moxy\bin\Release\Morris.Moxy.1.6.0-Beta2.nupkg -k %MORRIS.NUGET.KEY% -s https://api.nuget.org/v3/index.json
+	dotnet nuget push .\Source\Lib\Morris.Moxy\bin\Release\Morris.Moxy.1.6.0.nupkg -k %MORRIS.NUGET.KEY% -s https://api.nuget.org/v3/index.json
 )
 

--- a/Source/Lib/Directory.Build.props
+++ b/Source/Lib/Directory.Build.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
 	<TargetFramework>netstandard2.0</TargetFramework>
 	<LangVersion>10</LangVersion>
-	<Version>1.6-Beta2</Version>
+	<Version>1.6.0-Beta2</Version>
 
 	<Authors>Peter Morris</Authors>
 	<Company />

--- a/Source/Lib/Directory.Build.props
+++ b/Source/Lib/Directory.Build.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
 	<TargetFramework>netstandard2.0</TargetFramework>
 	<LangVersion>10</LangVersion>
-	<Version>1.6-Beta1</Version>
+	<Version>1.6-Beta2</Version>
 
 	<Authors>Peter Morris</Authors>
 	<Company />

--- a/Source/Lib/Directory.Build.props
+++ b/Source/Lib/Directory.Build.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
 	<TargetFramework>netstandard2.0</TargetFramework>
 	<LangVersion>10</LangVersion>
-	<Version>1.5</Version>
+	<Version>1.6-Beta1</Version>
 
 	<Authors>Peter Morris</Authors>
 	<Company />

--- a/Source/Lib/Directory.Build.props
+++ b/Source/Lib/Directory.Build.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
 	<TargetFramework>netstandard2.0</TargetFramework>
 	<LangVersion>10</LangVersion>
-	<Version>1.6.0-Beta2</Version>
+	<Version>1.6.0</Version>
 
 	<Authors>Peter Morris</Authors>
 	<Company />

--- a/Source/Lib/Morris.Moxy/Extensions/ScriptObjectAddVariablesForAttributeInstanceArgumentsExtension.cs
+++ b/Source/Lib/Morris.Moxy/Extensions/ScriptObjectAddVariablesForAttributeInstanceArgumentsExtension.cs
@@ -7,11 +7,13 @@ namespace Morris.Moxy.Extensions;
 internal static class ScriptObjectAddVariablesForAttributeInstanceArgumentsExtension
 {
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public static void AddVariablesForAttributeInstanceArguments(this ScriptObject scriptObject, AttributeInstance attributeInstance)
+	public static void AddVariablesForAttributeInstanceArguments(
+		this ScriptObject scriptObject,
+		AttributeInstance attributeInstance)
 	{
 		for (int i = 0; i < attributeInstance.Arguments.Length; i++)
 		{
-			KeyValuePair<string, string> argument = attributeInstance.Arguments[i];
+			KeyValuePair<string, object?> argument = attributeInstance.Arguments[i];
 			scriptObject.Add(argument.Key, argument.Value);
 		}
 	}

--- a/Source/Lib/Morris.Moxy/Metas/Classes/AttributeInstance.cs
+++ b/Source/Lib/Morris.Moxy/Metas/Classes/AttributeInstance.cs
@@ -6,20 +6,20 @@ namespace Morris.Moxy.Metas.Classes;
 internal class AttributeInstance : IEquatable<AttributeInstance>
 {
 	public readonly string Name;
-	public readonly ImmutableArray<KeyValuePair<string, string>> Arguments;
+	public readonly ImmutableArray<KeyValuePair<string, object?>> Arguments;
 
 	private readonly Lazy<int> CachedHashCode;
 
 	public AttributeInstance()
 	{
 		Name = "";
-		Arguments = ImmutableArray<KeyValuePair<string, string>>.Empty;
+		Arguments = ImmutableArray<KeyValuePair<string, object?>>.Empty;
 		CachedHashCode = new Lazy<int>(() => typeof(AttributeInstance).GetHashCode());
 	}
 
 	public AttributeInstance(
 		string name,
-		ImmutableArray<KeyValuePair<string, string>> arguments)
+		ImmutableArray<KeyValuePair<string, object?>> arguments)
 	{
 		if (name.EndsWith("Attribute"))
 			name = name.Substring(0, name.Length - 10);

--- a/Source/Lib/Morris.Moxy/SourceGenerators/ClassSourceGenerator.cs
+++ b/Source/Lib/Morris.Moxy/SourceGenerators/ClassSourceGenerator.cs
@@ -23,6 +23,9 @@ internal static class ClassSourceGenerator
 	{
 		for (int i = 0; i < classMetas.Length; i++)
 		{
+			if (productionContext.CancellationToken.IsCancellationRequested)
+				return;
+
 			ClassMeta classMeta = classMetas[i];
 			GenerateForClassMeta(productionContext, compiledTemplate, classMeta);
 		}
@@ -31,6 +34,9 @@ internal static class ClassSourceGenerator
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	private static void GenerateForClassMeta(SourceProductionContext productionContext, CompiledTemplate compiledTemplate, ClassMeta classMeta)
 	{
+		if (productionContext.CancellationToken.IsCancellationRequested)
+			return;
+
 		var filteredTemplates = classMeta.PossibleTemplates.Where(x => x.Name == compiledTemplate.Name).ToImmutableArray();
 		GenerateForGroupedTemplates(productionContext, compiledTemplate, classMeta, filteredTemplates);
 	}
@@ -45,6 +51,9 @@ internal static class ClassSourceGenerator
 		int fileIndex = 1;
 		for (int i = 0; i < attributeInstances.Length; i++)
 		{
+			if (productionContext.CancellationToken.IsCancellationRequested)
+				return;
+
 			AttributeInstance attributeInstance = attributeInstances[i];
 			GenerateForTemplate(productionContext, compiledTemplate, classMeta, attributeInstance, fileIndex++);
 		}
@@ -58,6 +67,9 @@ internal static class ClassSourceGenerator
 		AttributeInstance attributeInstance,
 		int index)
 	{
+		if (productionContext.CancellationToken.IsCancellationRequested)
+			return;
+
 		string? generatedSourceCode = null;
 		string classFileName = $"{classMeta.FullName}.{compiledTemplate.Name}.Instance{index}.MixinCode.Moxy.g.cs"
 			.Replace("<", "{")
@@ -75,7 +87,7 @@ internal static class ClassSourceGenerator
 			};
 			productionContext.AddCompilationError("", compilationError);
 		}
-		if (generatedSourceCode is not null)
+		if (generatedSourceCode is not null && !productionContext.CancellationToken.IsCancellationRequested)
 			productionContext.AddSource(
 				hintName: classFileName,
 				source: generatedSourceCode);
@@ -88,6 +100,9 @@ internal static class ClassSourceGenerator
 		ClassMeta classMeta,
 		AttributeInstance attributeInstance)
 	{
+		if (productionContext.CancellationToken.IsCancellationRequested)
+			return null;
+
 		using var stringWriter = new StringWriter();
 		using var writer = new IndentedTextWriter(stringWriter);
 		writer.WriteLine($"// Generated at {DateTime.UtcNow:yyyy-MM-dd HH:mm:ss} UTC");

--- a/Source/Lib/Morris.Moxy/SourceGenerators/TemplateAttributeSourceGenerator.cs
+++ b/Source/Lib/Morris.Moxy/SourceGenerators/TemplateAttributeSourceGenerator.cs
@@ -36,7 +36,7 @@ internal static class TemplateAttributeSourceGenerator
 			productionContext.AddCompilationError("", compilationError);
 		}
 
-		if (generatedSourceCode is not null)
+		if (generatedSourceCode is not null && !productionContext.CancellationToken.IsCancellationRequested)
 			productionContext.AddSource(
 				hintName: classFileName,
 				source: generatedSourceCode);


### PR DESCRIPTION
## New in 1.6
* Honour Roslyn `ProductionContext.Cancellation.IsCancellationRequested` to improve performance
* Do not output `typeof()` in generated source when user has specified a type name as a mixin argument [Fixes #28](https://github.com/mrpmorris/Morris.Moxy/issues/28)
* Use object instead of string for variable values [Fixes #30](https://github.com/mrpmorris/Morris.Moxy/issues/30)