### PR TITLE
Add DeclaringType to the FileName to avoid duplicates.  And shorten

### DIFF
--- a/Source/Lib/Morris.Moxy/SourceGenerators/ClassSourceGenerator.cs
+++ b/Source/Lib/Morris.Moxy/SourceGenerators/ClassSourceGenerator.cs
@@ -71,10 +71,11 @@ internal static class ClassSourceGenerator
 			return;
 
 		string? generatedSourceCode = null;
-		string classFileName = $"{classMeta.FullName}.{compiledTemplate.Name}.Instance{index}.MixinCode.Moxy.g.cs"
+		string classFileName = $"{classMeta.DeclaringTypeName}.{classMeta.ClassName}.{compiledTemplate.Name}.{index}.Moxy.g.cs"
 			.Replace("<", "{")
-			.Replace(">", "}");
-
+			.Replace(">", "}")
+			.TrimStart('.');
+		
 		try
 		{
 			generatedSourceCode = GenerateSourceCodeForAttributeInstance(productionContext, compiledTemplate, classMeta, attributeInstance);

--- a/Source/Lib/Morris.Moxy/SourceGenerators/ClassSourceGenerator.cs
+++ b/Source/Lib/Morris.Moxy/SourceGenerators/ClassSourceGenerator.cs
@@ -71,9 +71,10 @@ internal static class ClassSourceGenerator
 			return;
 
 		string? generatedSourceCode = null;
-		string classFileName = $"{classMeta.DeclaringTypeName}.{classMeta.ClassName}.{compiledTemplate.Name}.{index}.Moxy.g.cs"
+		string classFileName = $"{classMeta.Namespace}.{classMeta.DeclaringTypeName}.{classMeta.ClassName}.{compiledTemplate.Name}.{index}.Moxy.g.cs"
 			.Replace("<", "{")
 			.Replace(">", "}")
+			.Replace("..", ".")
 			.TrimStart('.');
 		
 		try


### PR DESCRIPTION
Fixes #45 

Also shortens the name to help avoid:

warning: could not open directory 'xxx': Filename too long

